### PR TITLE
Remove false positive Academic Torrents

### DIFF
--- a/all-torrent-websites.txt
+++ b/all-torrent-websites.txt
@@ -90,7 +90,6 @@ abetterplace2b.com
 abetterplace2b.org
 abtorrents.com
 academic-p2p.appspot.com
-academictorrents.com
 acehd.net
 acetorrents.net
 acg.rip


### PR DESCRIPTION
Hello,

The platform Academic Torrents is a 501(c)3 non-profit working to facilitate the distribution of scientific data. The platform does not allow piracy and should not be included in a list of piracy sites. Only educational and approved accounts are allow to upload torrent files.

-Joseph